### PR TITLE
allow-long-blocks-in-routes-files

### DIFF
--- a/.rubocop.ruby3-rails7.yml
+++ b/.rubocop.ruby3-rails7.yml
@@ -64,3 +64,7 @@ Metrics/MethodLength:
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsblocklength
 Metrics/BlockLength:
   <<: *line_count_metrics
+  # Allow large blocks in routes
+  Exclude:
+    - config/routes/*_routes.rb
+    - config/routes.rb


### PR DESCRIPTION
Hi Team,
please discuss the changed config.
I would like to allow larger blocks in routes files to not get notified by rubocop.


# Old Config

```ruby
# frozen_string_literal: true

namespace :maintenance do # <<< BLOCK HAS TOO MANY LINES
  root to: 'dashboard#show'
  get 'dashboard', to: 'dashboard#show'

  # draws routes from config/routes/kitchen_sink_routes.rb
  draw(:kitchen_sink_routes)

  resources :accountancy_changelogs, only: %i[index show] do
    post :index, on: :collection
  end

  resources :banlists, except: :show
  resources :business_audit_settings, only: %i[index edit update destroy]

  resources :general_settings, only: %i[index show edit update] do
    get :dashboard, on: :collection
  end

  resources :ghost_orders, only: %i[index destroy]

  namespace :verification do
    resources :scores, only: %i[index new update] do
      get :ajax_form_content, on: :collection
      get :all, on: :collection
      get :partners, on: :member
    end

    resources :settings, only: %i[index edit update] do
      post :edit, on: :member
      post :update_verification_settings, on: :collection
    end
  end

  resources :wrong_state_orders, only: [:index] do
    post :settle_all, on: :collection
  end
end
```

# New Config
Allows blocks with more than 25 lines so everything is fine with this snippet above.