### PR TITLE
Update .rubocop.ruby3-rails7.yml

### DIFF
--- a/.rubocop.ruby3-rails7.yml
+++ b/.rubocop.ruby3-rails7.yml
@@ -68,3 +68,9 @@ Metrics/BlockLength:
   Exclude:
     - config/routes/*_routes.rb
     - config/routes.rb
+
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength
+Layout/LineLength:
+  # allow lines longer than 120 (by default) characters if they are comment lines
+  # this is mainly for schema comments from annotate gem
+  AllowedPatterns: ['(\A|\s)#']


### PR DESCRIPTION
# Why the change?
The current (mostly default) rubocop config restricts the line length to 120 characters. While this is a reasonable config for code lines it is not (all the time) for comment lines. Especially not for auto generated lines by the annotate gem (schema comments).

# What changes?
The cop `Layout/LineLength`: [DOCS](https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength)
## From

```yaml
Layout/LineLength:
  Enabled: true
```

_It is enabled by default so not having the cop configured is implicitly enabling the cop)._
  
## To

```yaml
Layout/LineLength:
  Enabled: true
  AllowedPatterns: ['(\A|\s)#']
```

@aifinyo-ag/backoffice please discuss this proposal until Friday 12.07.2024. If you have not participated until then I will assume your acceptance of this change an merge it. Feel free to discuss the change afterwards with the team.