### PR TITLE
feat: use plugin config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 ---
 # shared configuration of rubocop
 
-require:
+plugins:
   - rubocop-rails
   - rubocop-performance
   - rubocop-minitest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ end
 ### .rubocop.yml
 
 > [!CAUTION]
-> This config only works from rubocop version 1.72 and up.
+> This config only works from rubocop version 1.72 and up so use `>= 1.72.0` as version constraint.
 
 Add this line to your application's .rubocop.yml:
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ end
 
 ### .rubocop.yml
 
+> [!CAUTION]
+> This config only works from rubocop version 1.72 and up.
+
 Add this line to your application's .rubocop.yml:
 
 ```yaml


### PR DESCRIPTION
- rubocop 1.72 introduced plugins, we are now using the config accordingly

Refs: [Migration Guide](https://docs.rubocop.org/rubocop/plugin_migration_guide.html)