### PR TITLE
feat: stop requiring top level docs on test files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,4 @@ Style/Documentation:
   Exclude:
     # no need to class document migrations
     - db/migrate/**/*.rb
+    - test/**/*.rb


### PR DESCRIPTION
Currently rubocop requires Top Level Documentation on test file.
This should not be required since the test should describe itself.