### PR TITLE
feat: disable Style/ClassAndModuleChildren

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,7 @@ Style/Documentation:
     # no need to class document migrations
     - db/migrate/**/*.rb
     - test/**/*.rb
+
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ClassAndModuleChildren
+Style/ClassAndModuleChildren:
+  Enabled: false


### PR DESCRIPTION
- Allow both compact and nested style for modules and classes


In order to be able to implement [scoped concerns like this](https://github.com/aifinyo-ag/infact5/blob/production/app/models/order/purchasable.rb#L8) without the need to manually disable this cop I want to disable it org-wide.

This allows all combinations:

```ruby
module Foo::Bar; end

module Foo
  module Bar; end
end

class Foo::Bar; end

module Foo
  class Bar; end
end

# ...  
```

Please discuss and/or accept the suggested changes by adding your review to this PR.
If there is no veto until **2025-07-08 eob** this change will be considered accepted by everyone and rolled out to all apps using this config.