### PR TITLE
fix: prefix Exclude/Include paths with "**/" for remote config compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,13 @@
 # shared configuration of rubocop
+#
+# IMPORTANT: All Exclude/Include paths MUST be quoted and prefixed with "**/".
+# Example: "**/test/**/*.rb" instead of test/**/*.rb
+#
+# Since RuboCop 1.84+ remote configs are cached in ~/.cache/rubocop_cache/ (see
+# https://github.com/rubocop/rubocop/pull/14870). Relative paths in this file
+# get resolved relative to that cache directory — not the project root. Using
+# the "**/" prefix makes patterns match regardless of the cache location.
+# Without it, Exclude directives silently fail to match any project files.
 
 plugins:
   - rubocop-rails
@@ -9,19 +18,19 @@ plugins:
 AllCops:
   DisplayCopNames: true
   Exclude:
-    - bin/**/*
-    - exe/**/*
-    - tmp/**/*
-    - public/**/*
-    - vendor/**/*
-    - node_modules/**/*
-    - db/schema.rb
+    - "**/bin/**/*"
+    - "**/exe/**/*"
+    - "**/tmp/**/*"
+    - "**/public/**/*"
+    - "**/vendor/**/*"
+    - "**/node_modules/**/*"
+    - "**/db/schema.rb"
       # Evaluate git config to exclude all ignored files and folders from rubocop checks.
       # The indentation is to not show the error "Invalid child element in a block sequence" in the editor (by yaml check).
       # Since this file is pre-processed by ERB, the indentation is not visible in the final file.
       # See: https://docs.rubocop.org/rubocop/configuration.html#pre-processing
       <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
-    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>
+    - "<%= "**/" + path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>"
       <% end %>
   NewCops: enable
   UseCache: false
@@ -52,8 +61,8 @@ Metrics/ModuleLength: &line_count_metrics
     - heredoc
   CountComments: false
   Exclude:
-    - test/**/*.rb
-    - spec/**/*.rb
+    - "**/test/**/*.rb"
+    - "**/spec/**/*.rb"
 
 # Following a team meeting on 4 September 2025, we decided to increase the maximum ABC size per method to 20.
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize
@@ -65,9 +74,9 @@ Metrics/BlockLength:
   <<: *line_count_metrics
   # Allow large blocks in configs (environments, initializers, routes, etc)
   Exclude:
-    - config/**/*.rb
-    - test/**/*.rb
-    - spec/**/*.rb
+    - "**/config/**/*.rb"
+    - "**/test/**/*.rb"
+    - "**/spec/**/*.rb"
 
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength
 Metrics/ClassLength:
@@ -87,7 +96,7 @@ Metrics/MethodLength:
 Rails/I18nLocaleTexts:
   Enabled: true
   Exclude:
-    - db/**/*
+    - "**/db/**/*"
 
 # Per team discussion from 14.03.2024 we decided to prefer and enforce the use of 'referrer' over 'referer'
 Rails/RequestReferer:
@@ -115,8 +124,8 @@ Style/Documentation:
   Enabled: true
   Exclude:
     # no need to class document migrations
-    - db/migrate/**/*.rb
-    - test/**/*.rb
+    - "**/db/migrate/**/*.rb"
+    - "**/test/**/*.rb"
 
 # Following a team discussion on 27 January 2026, we decided to enforce consistent syntax to not mix short { name: } and long { name: name } if at least one key cannot be omitted (requires Ruby 3.1+).
 # https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ AllCops:
       # Since this file is pre-processed by ERB, the indentation is not visible in the final file.
       # See: https://docs.rubocop.org/rubocop/configuration.html#pre-processing
       <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
-    - "<%= "**/" + path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>"
+    - "<%= '**/' + path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>"
       <% end %>
   NewCops: enable
   UseCache: false


### PR DESCRIPTION
## Summary

- All `Exclude`/`Include` paths are now quoted and prefixed with `"**/"` 
- ERB-generated paths from `git status --ignored` are also prefixed
- Added documentation header explaining why this is necessary

## Problem

Since [RuboCop 1.84+](https://github.com/rubocop/rubocop/pull/14870), remote configs are cached in `~/.cache/rubocop_cache/` instead of the project root. All relative paths in `Exclude`/`Include` directives get resolved relative to that cache directory — not the project root. This caused exclusions like `test/**/*.rb` to silently fail, e.g. `Style/Documentation` was flagging test files that should have been excluded.

## Solution

Prefixing all paths with `"**/"` makes glob patterns match regardless of where the config file is cached. The quotes are required because `*` is a YAML alias indicator and causes parse errors when unquoted at the start of a value.

## Test plan

- [x] Verified `bundle exec rubocop --show-cops Style/Documentation` resolves Exclude paths to the project directory
- [x] Verified test files are no longer flagged by `Style/Documentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)