### PR TITLE
fix: rename config to fix Exclude path resolution for remote inheritance

### DIFF
--- a/shared_rubocop.yml
+++ b/shared_rubocop.yml
@@ -1,13 +1,15 @@
 # shared configuration of rubocop
 #
-# IMPORTANT: All Exclude/Include paths MUST be quoted and prefixed with "**/".
-# Example: "**/test/**/*.rb" instead of test/**/*.rb
+# IMPORTANT: This file is intentionally NOT named .rubocop.yml.
 #
-# Since RuboCop 1.84+ remote configs are cached in ~/.cache/rubocop_cache/ (see
-# https://github.com/rubocop/rubocop/pull/14870). Relative paths in this file
-# get resolved relative to that cache directory — not the project root. Using
-# the "**/" prefix makes patterns match regardless of the cache location.
-# Without it, Exclude directives silently fail to match any project files.
+# Since RuboCop 1.84+ (https://github.com/rubocop/rubocop/pull/14870), remote
+# configs are cached in ~/.cache/rubocop_cache/. RuboCop's `base_dir_for_path_parameters`
+# resolves relative Exclude/Include paths based on the cached config's directory —
+# but only when the filename starts with ".rubocop". By naming this file
+# "shared_rubocop.yml", RuboCop falls back to Dir.pwd (the project root),
+# and all relative paths resolve correctly.
+#
+# See also: https://github.com/rubocop/rubocop/pull/14761
 
 plugins:
   - rubocop-rails
@@ -18,19 +20,19 @@ plugins:
 AllCops:
   DisplayCopNames: true
   Exclude:
-    - "**/bin/**/*"
-    - "**/exe/**/*"
-    - "**/tmp/**/*"
-    - "**/public/**/*"
-    - "**/vendor/**/*"
-    - "**/node_modules/**/*"
-    - "**/db/schema.rb"
+    - bin/**/*
+    - exe/**/*
+    - tmp/**/*
+    - public/**/*
+    - vendor/**/*
+    - node_modules/**/*
+    - db/schema.rb
       # Evaluate git config to exclude all ignored files and folders from rubocop checks.
       # The indentation is to not show the error "Invalid child element in a block sequence" in the editor (by yaml check).
       # Since this file is pre-processed by ERB, the indentation is not visible in the final file.
       # See: https://docs.rubocop.org/rubocop/configuration.html#pre-processing
       <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
-    - "<%= '**/' + path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>"
+    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*') %>
       <% end %>
   NewCops: enable
   UseCache: false
@@ -61,8 +63,8 @@ Metrics/ModuleLength: &line_count_metrics
     - heredoc
   CountComments: false
   Exclude:
-    - "**/test/**/*.rb"
-    - "**/spec/**/*.rb"
+    - test/**/*.rb
+    - spec/**/*.rb
 
 # Following a team meeting on 4 September 2025, we decided to increase the maximum ABC size per method to 20.
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize
@@ -74,9 +76,9 @@ Metrics/BlockLength:
   <<: *line_count_metrics
   # Allow large blocks in configs (environments, initializers, routes, etc)
   Exclude:
-    - "**/config/**/*.rb"
-    - "**/test/**/*.rb"
-    - "**/spec/**/*.rb"
+    - config/**/*.rb
+    - test/**/*.rb
+    - spec/**/*.rb
 
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength
 Metrics/ClassLength:
@@ -96,7 +98,7 @@ Metrics/MethodLength:
 Rails/I18nLocaleTexts:
   Enabled: true
   Exclude:
-    - "**/db/**/*"
+    - db/**/*
 
 # Per team discussion from 14.03.2024 we decided to prefer and enforce the use of 'referrer' over 'referer'
 Rails/RequestReferer:
@@ -124,8 +126,8 @@ Style/Documentation:
   Enabled: true
   Exclude:
     # no need to class document migrations
-    - "**/db/migrate/**/*.rb"
-    - "**/test/**/*.rb"
+    - db/migrate/**/*.rb
+    - test/**/*.rb
 
 # Following a team discussion on 27 January 2026, we decided to enforce consistent syntax to not mix short { name: } and long { name: name } if at least one key cannot be omitted (requires Ruby 3.1+).
 # https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax


### PR DESCRIPTION
## Summary

- Rename `.rubocop.yml` → `shared_rubocop.yml`
- Revert `"**/"` prefix workaround (no longer needed)
- Document the root cause in the file header

## Problem

Since RuboCop 1.84+ ([#14870](https://github.com/rubocop/rubocop/pull/14870)), remote configs are cached in `~/.cache/rubocop_cache/` instead of the project root. RuboCop's [`base_dir_for_path_parameters`](https://github.com/rubocop/rubocop/blob/v1.84.1/lib/rubocop/config.rb#L283-L291) resolves relative `Exclude`/`Include` paths based on the cached config's directory — **but only when the filename starts with `.rubocop`**:

```ruby
def base_dir_for_path_parameters
  if loaded_path && File.basename(loaded_path).start_with?('.rubocop') && ...
    File.expand_path(File.dirname(loaded_path))  # → cache dir ❌
  else
    Dir.pwd  # → project root ✅
  end
end
```

This caused all `Exclude` directives (e.g. `test/**/*.rb`, `db/migrate/**/*.rb`) to silently fail, because they resolved to paths inside the cache directory where no project files exist.

### What we tried (and why it didn't work)

- **`"**/test/**/*.rb"` prefix**: `File.expand_path` treats `**` as a literal path component, resulting in `/Users/.../.cache/rubocop_cache/**/test/**/*.rb` — still rooted in the cache dir.
- **`CacheRootDirectory: .`**: RuboCop always appends `rubocop_cache/` subdirectory ([source](https://github.com/rubocop/rubocop/blob/v1.84.1/lib/rubocop/cache_config.rb#L26)), so the config still wouldn't land in the project root.

## Solution

Rename the file so it does **not** start with `.rubocop`. This makes `base_dir_for_path_parameters` return `Dir.pwd` (the project root), and all relative paths resolve correctly. This behavior is by design — see [PR #14761](https://github.com/rubocop/rubocop/pull/14761).

## Breaking Change

All projects inheriting this config must update their `inherit_from` URL:

```yaml
inherit_from:
  - https://raw.githubusercontent.com/aifinyo-ag/rubocop-config/main/shared_rubocop.yml
```

## Test plan

- [x] Verify `bundle exec rubocop --show-cops Style/Documentation` shows Exclude paths relative to the project root
- [x] Verify test files are no longer flagged by `Style/Documentation`
- [x] Update `inherit_from` in all consuming projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)